### PR TITLE
Added cronjob to auto-delete expired rooms every 20 mins

### DIFF
--- a/server/cronJobs/roomCleanup.js
+++ b/server/cronJobs/roomCleanup.js
@@ -1,0 +1,20 @@
+// server/cronJobs/roomCleanup.js
+
+import cron from "node-cron";
+import Room from "../models/Room.js";
+
+export const scheduleRoomCleanup = () => {
+  cron.schedule("* * * * *", async () => {
+    const twentyMinsAgo = new Date(Date.now() - 20 * 60 * 1000);
+
+    try {
+      const result = await Room.deleteMany({ createdAt: { $lt: twentyMinsAgo } });
+
+      if (result.deletedCount > 0) {
+        console.log(`Deleted ${result.deletedCount} expired room at ${new Date().toLocaleTimeString()}`);
+      }
+    } catch (err) {
+      console.error("Error during room cleanup:", err.message);
+    }
+  });
+};


### PR DESCRIPTION
PR Concept: Cronjobs or scheduled jobs

Added a cronjob using `node-cron` in `server/cronjobs/roomCleanup.js`.  
This runs every minute and deletes all rooms older than 20 minutes based on their `createdAt` timestamp.

- Keeps the database clean  
- Runs automatically in the background  
- Logs deleted count to console  